### PR TITLE
refactor:  include additional data structures and types of metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,7 +954,8 @@ pub struct PointOfContact {
     #[serde(rename = "contactName")]
     pub contact_name: String,
     #[serde(rename = "contactType")]
-    pub contact_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact_type: Option<String>,
     #[serde(rename = "role")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Error, Value};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Error, Value};
-use std::{array, collections::HashMap};
 
 #[derive(Clone)]
 pub enum SortingStrategy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,7 +962,6 @@ pub struct PointOfContact {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(rename = "emailAddress")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub email_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub website: Option<String>,
@@ -979,6 +978,7 @@ pub struct PointOfContact {
 /// - `{version}` designates the specific version of the CRS
 ///   (use "0" if there is no version)
 /// - `{code}` is the identifier for the specific coordinate reference system
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReferenceSystem {
     pub authority: String,
     pub version: String,
@@ -1024,15 +1024,21 @@ impl ReferenceSystem {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Metadata {
     #[serde(rename = "geographicalExtent")]
-    pub geographical_extent: GeographicalExtent,
-    pub identifier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub geographical_extent: Option<GeographicalExtent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
     #[serde(rename = "pointOfContact")]
-    pub point_of_contact: PointOfContact,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub point_of_contact: Option<PointOfContact>,
     #[serde(rename = "referenceDate")]
-    pub reference_date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_date: Option<String>,
     #[serde(rename = "referenceSystem")]
-    pub reference_system: String,
-    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_system: Option<ReferenceSystem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -993,7 +993,9 @@ impl ReferenceSystem {
         }
     }
 
-    pub fn to_url(&self, base_url: &str) -> String {
+    pub fn to_url(&self, base_url: Option<&str>) -> String {
+        let base_url = base_url.unwrap_or("http://www.opengis.net/def/crs");
+
         format!(
             "{}/{}/{}/{}",
             base_url, self.authority, self.version, self.code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -978,7 +978,6 @@ pub struct PointOfContact {
 /// - `{version}` designates the specific version of the CRS
 ///   (use "0" if there is no version)
 /// - `{code}` is the identifier for the specific coordinate reference system
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReferenceSystem {
     pub authority: String,
     pub version: String,
@@ -1031,7 +1030,7 @@ pub struct Metadata {
     #[serde(rename = "referenceDate")]
     pub reference_date: String,
     #[serde(rename = "referenceSystem")]
-    pub reference_system: ReferenceSystem,
+    pub reference_system: String,
     pub title: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -968,7 +968,15 @@ pub struct PointOfContact {
     pub address: Option<Address>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// A reference system following the OGC Name Type Specification.
+///
+/// The format follows: `http://www.opengis.net/def/crs/{authority}/{version}/{code}`
+/// where:
+/// - `{authority}` designates the authority responsible for the definition of this CRS
+///   (usually "EPSG" or "OGC")
+/// - `{version}` designates the specific version of the CRS
+///   (use "0" if there is no version)
+/// - `{code}` is the identifier for the specific coordinate reference system
 pub struct ReferenceSystem {
     pub authority: String,
     pub version: String,
@@ -991,7 +999,9 @@ impl ReferenceSystem {
         )
     }
 
+    // OGC Name Type Specification:
     // http://www.opengis.net/def/crs/{authority}/{version}/{code}
+    // where {authority} designates the authority responsible for the definition of this CRS (usually "EPSG" or "OGC"), and where {version} designates the specific version of the CRS ("0" (zero) is used if there is no version).
     pub fn from_url(url: &str) -> Result<Self, &'static str> {
         let parts: Vec<&str> = url.split("/").collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Error, Value};
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub enum SortingStrategy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -978,6 +978,7 @@ pub struct PointOfContact {
 /// - `{version}` designates the specific version of the CRS
 ///   (use "0" if there is no version)
 /// - `{code}` is the identifier for the specific coordinate reference system
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReferenceSystem {
     pub authority: String,
     pub version: String,
@@ -1030,7 +1031,7 @@ pub struct Metadata {
     #[serde(rename = "referenceDate")]
     pub reference_date: String,
     #[serde(rename = "referenceSystem")]
-    pub reference_system: String,
+    pub reference_system: ReferenceSystem,
     pub title: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,7 +962,7 @@ pub struct PointOfContact {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(rename = "emailAddress")]
-    pub email_address: Option<String>,
+    pub email_address: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub website: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION

# What
This pull request introduces a stricter type declaration for the `Metadata` field in accordance with the CityJSON specification. The previous implementation used `Option<Value>` for the `Metadata` type, which made type inference challenging for the program. By explicitly defining the type, we enhance type safety and improve code clarity.
