### PR TITLE
Add WASM support with bindings for CityJSONSeq operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 homepage = "https://github.com/cityjson/cjseq"
 repository = "https://github.com/cityjson/cjseq"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,4 +21,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # serde_derive = "1.0"
 
+# WASM dependencies
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.6"
 
+[dependencies.web-sys]
+version = "0.3"
+features = ["console"]
+
+# WASM-specific dependencies
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+getrandom = { version = "0.2", features = ["js"] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Usage
 
-`cjseq` takes input from either a file or the standard input (stdin, if no file path is given as argument), and it always outputs the results to the standard output (stdout). 
+`cjseq` takes input from either a file or the standard input (stdin, if no file path is given as argument), and it always outputs the results to the standard output (stdout).
 The output can be a CityJSON object or a CityJSONSeq stream.
 
 ### Convert CityJSON to CityJSONSeq
@@ -70,3 +70,17 @@ cat ./data/*.city.jsonl | cjseq collect > hugefile.city.json
 
   1. the input CityJSON/Seq must be v1.1 or v2.0 (v1.0 will panic).
   2. the input JSON must be CityJSON schema-valid, use [cjval](https://github.com/cityjson/cjval) to validate.
+
+## WASM bindings
+
+`cjseq` can be used in JavaScript/TypeScript applications via WASM bindings.
+
+```sh
+cargo install wasm-pack
+```
+
+Build the WASM bindings:
+
+```sh
+wasm-pack build --release --target web --out-dir js
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1221,3 +1221,25 @@ impl Appearance {
         };
     }
 }
+
+/// Collects a base CityJSON metadata and a vector of CityJSONFeatures
+/// into a complete CityJSON object
+pub fn cjseq_to_cj(mut base_cj: CityJSON, features: Vec<CityJSONFeature>) -> CityJSON {
+    for mut feature in features {
+        base_cj.add_cjfeature(&mut feature);
+    }
+
+    base_cj.remove_duplicate_vertices();
+    base_cj.update_transform();
+    base_cj.update_geographicalextent();
+
+    base_cj
+}
+
+// WASM bindings module
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
+// Re-export WASM functions for convenience
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,66 @@
+//! WASM bindings for CityJSONSeq operations
+//!
+//! This module provides WebAssembly bindings for the cjseq library,
+//! allowing JavaScript/TypeScript applications to process CityJSONSeq
+//! files directly in the browser or Node.js.
+
+use crate::{cjseq_to_cj, CityJSON, CityJSONFeature};
+use serde_wasm_bindgen::{from_value, to_value};
+use wasm_bindgen::prelude::*;
+
+/// Initialize the WASM module with panic hook for better error messages
+#[wasm_bindgen(start)]
+pub fn main() {
+    console_error_panic_hook::set_once();
+}
+
+/// Convert a base CityJSON metadata and array of CityJSONFeatures into a complete CityJSON object
+///
+/// # Arguments
+/// * `base_cj` - The base CityJSON metadata object (typically first line of CityJSONSeq)
+/// * `features` - Array of CityJSONFeature objects
+///
+/// # Returns
+/// * `Result<JsValue, JsValue>` - Complete CityJSON object or error
+///
+/// # Example
+/// ```javascript
+/// import init, { cjseqToCj } from './cjseq.js';
+///
+/// await init();
+/// const result = cjseqToCj(baseCityJSON, featuresArray);
+/// ```
+#[wasm_bindgen(js_name = cjseqToCj)]
+pub fn cjseq_to_cj_wasm(base_cj: JsValue, features: JsValue) -> Result<JsValue, JsValue> {
+    let base_cj: CityJSON = match from_value(base_cj) {
+        Ok(cj) => cj,
+        Err(e) => {
+            web_sys::console::error_1(&format!("failed to deserialize base_cj: {}", e).into());
+            return Err(JsValue::from_str(&format!(
+                "failed to parse base_cj: {}",
+                e
+            )));
+        }
+    };
+
+    let features: Vec<CityJSONFeature> = match from_value(features) {
+        Ok(f) => f,
+        Err(e) => {
+            web_sys::console::error_1(&format!("failed to deserialize features: {}", e).into());
+            return Err(JsValue::from_str(&format!(
+                "failed to parse features: {}",
+                e
+            )));
+        }
+    };
+
+    let cj = cjseq_to_cj(base_cj, features);
+
+    match to_value(&cj) {
+        Ok(js_val) => Ok(js_val),
+        Err(e) => {
+            web_sys::console::error_1(&format!("failed to serialize cj: {}", e).into());
+            Err(JsValue::from_str(&format!("failed to serialize cj: {}", e)))
+        }
+    }
+}


### PR DESCRIPTION
- Updated Cargo.toml to include WASM dependencies and configuration.
- Enhanced README.md with instructions for using cjseq in JavaScript/TypeScript via WASM.
- Implemented WASM bindings in a new wasm.rs module, allowing conversion of CityJSON metadata and features to a complete CityJSON object.
- Added error handling and serialization for WASM functions.